### PR TITLE
Added support for Chase

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -230,6 +230,11 @@
          "serviceName":"no provider name",
          "matcherPattern":"\\d{2,8}.+Valid",
          "codeExtractorPattern":"(\\d{2,8})"
-      }
+      },
+      {
+         "serviceName":"Chase",
+         "matcherPattern":"From: Chase\\nWe'll NEVER call you to ask for this code\\.\\nOne-Time Code:\\d{8,8}\\nOnly use this online\\. Code expires in 30 min\\.",
+         "codeExtractorPattern":"(\\d{8,8})"
+      },
    ]
 }


### PR DESCRIPTION
Chase sends text messages in this form:

From: Chase
We'll NEVER call you to ask for this code.
One-Time Code:00000000
Only use this online. Code expires in 30 min.

[where 00000000 is an 8-digit code obviously]

(Sorry I have no idea if I submitted correctly - feel free to edit/correct the RegEx to match the sample text I sent above more generally.)