### PR TITLE
Feature: Add Clipboard Restore Functionality 

### DIFF
--- a/TwoFHey/AppDelegate.swift
+++ b/TwoFHey/AppDelegate.swift
@@ -117,7 +117,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         let window = OverlayWindow(line1: message.1.code, line2: "Copied to Clipboard")
         
-        message.1.copyToClipboard()
+        message.1.copyToClipboard() { didRestoreContents in
+            if (didRestoreContents) {
+                let window = OverlayWindow(line1: "Clipboard contents restored", line2: nil)
+                self.overlayWindow = window
+            }
+        }
+        
         window.makeKeyAndOrderFront(nil)
         
         overlayWindow = window
@@ -172,6 +178,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         keyboardShortCutItem.state = AppStateManager.shared.globalShortcutEnabled ? .on : .off
         settingsMenu.addItem(keyboardShortCutItem)
 
+        let restoreContentsItem = NSMenuItem(title: "Restore Clipboard Contents", action: #selector(AppDelegate.onPressRestoreClipboardContents), keyEquivalent: "")
+        restoreContentsItem.toolTip = "Disable restore clipboard contents if you don't want 2FHey to restore your clipboard to what it was before receiving a code"
+        restoreContentsItem.state = AppStateManager.shared.restoreContentsEnabled ? .on : .off
+        settingsMenu.addItem(restoreContentsItem)
+
         let autoLaunchItem = NSMenuItem(title: "Open at Login", action: #selector(AppDelegate.onPressAutoLaunch), keyEquivalent: "")
         autoLaunchItem.state = AppStateManager.shared.shouldLaunchOnLogin ? .on : .off
         settingsMenu.addItem(autoLaunchItem)
@@ -212,6 +223,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         AppStateManager.shared.globalShortcutEnabled = !AppStateManager.shared.globalShortcutEnabled
         refreshMenu()
         setupGlobalKeyShortcut()
+    }
+    
+    @objc func onPressRestoreClipboardContents() {
+        AppStateManager.shared.restoreContentsEnabled = !AppStateManager.shared.restoreContentsEnabled
+        refreshMenu()
     }
     
     func setupGlobalKeyShortcut() {

--- a/TwoFHey/DataManagement/AppStateManager.swift
+++ b/TwoFHey/DataManagement/AppStateManager.swift
@@ -22,6 +22,7 @@ class AppStateManager {
         
         static let autoLauncherPrefKey = "com.sofriendly.2fhey.shouldAutoLaunch"
         static let globalShortcutEnabledKey = "com.sofriendly.2fhey.globalShortcutEnabled"
+        static let restoreContentsEnabledKey = "com.sofriendly.2fhey.restoreContentsEnabled"
         static let hasSetupKey = "com.sofriendly.2fhey.hasSetup"
     }
     
@@ -65,6 +66,15 @@ class AppStateManager {
         }
         set(newValue) {
             UserDefaults.standard.set(newValue, forKey: Constants.globalShortcutEnabledKey)
+        }
+    }
+    
+    var restoreContentsEnabled: Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: Constants.restoreContentsEnabledKey)
+        }
+        set(newValue) {
+            UserDefaults.standard.set(newValue, forKey: Constants.restoreContentsEnabledKey)
         }
     }
 }

--- a/TwoFHey/OTPParser/OTPParser.swift
+++ b/TwoFHey/OTPParser/OTPParser.swift
@@ -10,10 +10,21 @@ public struct ParsedOTP {
     public let service: String?
     public let code: String
     
-    
-    func copyToClipboard() {
+    func copyToClipboard(completion: @escaping (_ some: Bool) -> Void = { _ in })  {
+        // Check for setting here to avoid reading from clipboard unnecessarily
+        let originalContents = AppStateManager.shared.restoreContentsEnabled ? NSPasteboard.general.string(forType: .string) : nil
+        
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(code, forType: .string)
+        
+        if (originalContents != nil) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 20.0) {
+                NSPasteboard.general.setString(originalContents!, forType: .string)
+                completion(true)
+            }
+        } else {
+            completion(true)
+        }
     }
 }
 


### PR DESCRIPTION
Hey there,

Awesome job on this app! It has been working perfectly for me! Similar to other apps like 1Password I thought it would be cool to add Clipboard restore feature to this.

Apologies in advance for opening a PR without discussing first on an Issue, I happy to change anything you all like to fit your architecture or if this feature is not desired then I have no problem closing the PR. 

With the `Restore Clipboard Contents` settings item enabled, 2FHey will save what is currently in the user's clipboard before writing the code to the clipboard. After waiting 20sec it will restore the clipboard contents to what was there before.

**Notes**
- When I was writing this I didnt want to change too much to the core models (ie. I messed around with adding originalContents to Message but opted not to).
- I really wanted this feature to detect when the code was pasted and then perform the restore but NSPasteboard seems lacking on some listening/observing functionality, i guess it could listen for key strokes or system paste actions maybe? But felt 
- It would be nice to give users the option to configure the time interval but I wasn't entirely sure the best place for that option and figured it would be best to post what i've got first

