### PR TITLE
add DBS Bank SMS support

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -265,6 +265,11 @@
          "serviceName":"Geico",
          "matcherPattern":"GEICO: Your verification code is: \\w{6}. It expires in 10 minutes. Please do not reply to this message.",
          "codeExtractorPattern":": (\\w{6})."
+      },
+      {
+         "serviceName":"DBS Bank",
+         "matcherPattern":"To approve, use [A-Z]{3}-([0-9]{6}) within",
+         "codeExtractorPattern":"([0-9]{6})"
       }
    ]
 }


### PR DESCRIPTION
An example: 

Fr DBS: Do not reveal OTP to anyone for your online txn of on {payment and card information omitted} at {place info omitted}. To approve, use PRH-929890 within 3 min.