### PR TITLE
Add USPS to AppConfig.json

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -265,6 +265,11 @@
          "serviceName":"Geico",
          "matcherPattern":"GEICO: Your verification code is: \\w{6}. It expires in 10 minutes. Please do not reply to this message.",
          "codeExtractorPattern":": (\\w{6})."
+      },
+      {
+         "serviceName":"USPS",
+         "matcherPattern":"USPS Account Services: your validation code is \\w{6}\\nMsg & data rates may apply\\nReply HELP for help\\nReply STOP to cancel",
+         "codeExtractorPattern":": (\\w{6})."
       }
    ]
 }


### PR DESCRIPTION
These do not appear to be captured by 2fhey at the moment (old example):
<img width="288" alt="image" src="https://github.com/SoFriendly/2fhey/assets/228228/f76b4c5d-dedb-4fa7-a31c-d4c0683485b3">
