### PR TITLE
Update CN General

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -258,7 +258,7 @@
       },
       {
          "serviceName":"CN General",
-         "matcherPattern":"验证码([(是)(为)]?)(\\d{4,8})",
+         "matcherPattern":"验证码([是为：:\\s]*)(\\d{4,8})",
          "codeExtractorPattern":"(\\d{4,8})"
       },
       {


### PR DESCRIPTION
Supplement to #21

It can now detect the SMS verification codes of most services in China.

> Note that Bilibili in the format of `【哔哩哔哩】000000为本次登录验证的手机验证码，请在5分钟内完成验证。为保证账号安全，请勿泄漏此验证码` is still not supported.
