### PR TITLE
Update AppConfig.json to support myGov in Australia

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -325,6 +325,6 @@
          "serviceName": "myGov",
          "matcherPattern": "^myGov Security: Your security code is (\\d{6}).",
          "codeExtractorPattern": "(\\d{6})"
-      },   
+      }
    ]
 }

--- a/AppConfig.json
+++ b/AppConfig.json
@@ -320,6 +320,11 @@
          "serviceName": "Twitter",
          "matcherPattern": "Twitter login code: (\\d{6,9})",
          "codeExtractorPattern": "(\\d{6,9})"
-      }
+      },
+      {
+         "serviceName": "myGov",
+         "matcherPattern": "^myGov Security: Your security code is (\\d{6}).",
+         "codeExtractorPattern": "(\\d{6})"
+      },   
    ]
 }


### PR DESCRIPTION
This PR adds support for myGov, a SSO / centralised portal used by many Australia government services.

Messages come in the form of:

> myGov Security: Your security code is 123456. If this was not you, contact the myGov help desk on 132 307. Do not reply by SMS. Message reference: SV001

And currently the matchers pull out SV001.

This adds a customer matcher, to ensure we detect and copy the appropriate 2FA code.
