### PR TITLE
Update AppConfig.json adding support for Revolut Business

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -320,6 +320,11 @@
          "serviceName": "Twitter",
          "matcherPattern": "Twitter login code: (\\d{6,9})",
          "codeExtractorPattern": "(\\d{6,9})"
+      },
+      {
+	 "serviceName": "Revolut Business",
+  	 "matcherPattern": "in your Revolut Business app, use code: ",
+ 	 "codeExtractorPattern": "(\\d{3}-\\d{3})"
       }
    ]
 }

--- a/AppConfig.json
+++ b/AppConfig.json
@@ -326,7 +326,7 @@
          "matcherPattern": "Twitter login code: (\\d{6,9})",
          "codeExtractorPattern": "(\\d{6,9})"
       },
-     {
+      {
          "serviceName": "BforBank",
          "matcherPattern": "^BforBank :.+$",
          "codeExtractorPattern": "code: (\\d{6})"


### PR DESCRIPTION
added support for Revolut Business messages, as they usually match the post code of the location I'm trying to log in from, message example:
"To confirm bulk transfer in your Revolut Business app, use code: xxx-xxx. Don't share it with anyone. No one from Revolut will ever ask you for it. Device: Macintosh, macOS 10.15, Chrome 129. Location: Spain, Madrid, Madrid, 28007.  It will expire in 10 minutes. "