### PR TITLE
Fix syntax error in `AppConfig.json`

### DIFF
--- a/AppConfig.json
+++ b/AppConfig.json
@@ -369,7 +369,7 @@
       {
          "serviceName": "Spirica",
          "matcherPattern": "^Spirica$",
-         "codeExtractorPattern": "Code de confirmation : (\S{6})"
+         "codeExtractorPattern": "Code de confirmation : (\\S{6})"
       },
       {
   "serviceName": "Aeroplan",


### PR DESCRIPTION
Syntax error introduced in: https://github.com/SoFriendly/2fhey/pull/84

Fixes this error:

```
Downloading latest service config
Downloaded config data
Failed to decode config data
```
